### PR TITLE
Added return in PaymentSMS->doSmsRequest

### DIFF
--- a/tpayLibs/src/_class_tpay/PaymentSms.php
+++ b/tpayLibs/src/_class_tpay/PaymentSms.php
@@ -42,8 +42,8 @@ class PaymentSMS extends ObjectsHelper
             'tfCodeToCheck' => $codeToCheck,
             'tfHash'        => $hash,
         );
-        $this->isValidCode($this->requests($this->secureURL, $postData));
 
+        return $this->isValidCode($this->requests($this->secureURL, $postData));
     }
 
     /**


### PR DESCRIPTION
Hello 

In your examples "SmsNotification" you have 

`public function handleSmsNotification()
    {
        $result = $this->doSmsRequest();

        echo '<h1>sprawdzenie SMS</h1>';
        echo 'result: ' . (int)$result;
}`

but method doSmsRequest does not return "isValidCode" return. 
This is a small fix for this. 

