### PR TITLE
Update BasicNotificationHandler.php

### DIFF
--- a/tpayLibs/src/_class_tpay/Notifications/BasicNotificationHandler.php
+++ b/tpayLibs/src/_class_tpay/Notifications/BasicNotificationHandler.php
@@ -54,7 +54,7 @@ class BasicNotificationHandler extends BasicPaymentOptions
      * merchant and tpay system.
      *
      * @param string $md5sum md5 sum received from tpay
-     * @param float $transactionAmount transaction amount
+     * @param string $transactionAmount transaction amount
      * @param string $crc transaction crc
      *
      * @return bool


### PR DESCRIPTION
You actually pass string to isMd5Valid function instead of float. I have used this method outside of this library and added float to define parameters type and it caused invalid Md5 each time. So this should be stated that this is actually a string, not a float.