### PR TITLE
Update Curl.php

### DIFF
--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -142,7 +142,6 @@ class Curl extends CurlOptions
         $this->curlError = curl_error($ch);
         $this->curlErrorNumber = curl_errno($ch);
         $this->checkResponse();
-        curl_close($ch);
         $this->result = $curlRes;
 
         return $this;


### PR DESCRIPTION
https://github.com/tpay-com/tpay-php/issues/80
resolve php 8 error:
Function curl_close() is deprecated since 8.5, as it has no effect since PHP 8.0","file":"/.../vendor/tpay-com/tpay-php/src/Curl/Curl.php","line":145